### PR TITLE
fix: don't inherit default border

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,8 @@ const css = `
   /* Hide bottom border if tab is active, make bg lighter */
   .tab_tab {
     color: #{foregroundColor} !important;
+    border-left: 0 none;
+    border-right: 0 none;
   }
 
   .tab_active {


### PR DESCRIPTION
<img width="470" alt="screen shot 2016-09-22 at 12 03 25 pm" src="https://cloud.githubusercontent.com/assets/176984/18754103/d27bf8b0-80bd-11e6-9b2a-374531a093ef.png">

Changes in hyperterm passed a default border to `.tab_tab`. Set this to 0 so we can override it with `:active`.
